### PR TITLE
Fix errors that appear in PROBLEMS tab after opening a workspace

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,6 +10,7 @@ echo "post-create start" >> ~/status
 #sudo apt-get autoremove -y
 #sudo apt-get clean -y
 
-# add your commands here
+dotnet restore /workspaces/webvalidate/src/webvalidate.sln
+dotnet restore /workspaces/ngsa-app/Ngsa.App.csproj
 
 echo "post-create complete" >> ~/status


### PR DESCRIPTION
## Purpose of PR

Run dotnet restore for webv and ngsa projects in the post-create script. This resolves the errors that show up in the PROBLEMS tab for both projects after opening the cse-labs workspace.

![workspace-error-2](https://user-images.githubusercontent.com/3047161/151612473-75771026-fb5e-46a2-92d5-b83ae7c85c53.jpg)
![workspace-error-1](https://user-images.githubusercontent.com/3047161/151612477-069cf449-d344-42c5-a0de-b16322e8203b.jpg)


## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes
